### PR TITLE
[Change]: Prettier & React Rules Update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,157 +1,163 @@
 module.exports = {
-	extends: ['airbnb', 'prettier', 'eslint:recommended'],
-	parser: '@babel/eslint-parser',
-	parserOptions: {
-		ecmaVersion: 2020,
-		requireConfigFile: false,
-		ecmaFeatures: {
-			jsx: true,
-		},
-		babelOptions: {
-			presets: ['@babel/preset-react'],
-		},
-	},
-	env: {
-		browser: true,
-		node: true,
-		jquery: true,
-		jest: true,
-	},
-	plugins: ['html', 'prettier', 'react-hooks'],
-	rules: {
-		'prettier/prettier': [
-			'error',
-			{
-				trailingComma: 'es5',
-				singleQuote: true,
-				printWidth: 100,
-				bracketSpacing: true,
-				tabWidth: 4,
-				useTabs: true,
-				semi: true,
-				endOfLine: 'auto',
-			},
-		],
-		'no-use-before-define': 'off',
-		'no-debugger': 0,
-		'no-alert': 0,
-		'no-await-in-loop': 0,
-		'no-return-assign': ['error', 'except-parens'],
-		'no-restricted-syntax': [2, 'ForInStatement', 'LabeledStatement', 'WithStatement'],
-		'no-redeclare': 'off',
-		'no-unused-vars': [
-			1,
-			{
-				ignoreRestSiblings: true,
-				argsIgnorePattern: 'res|next|^err',
-			},
-		],
-		'prefer-const': [
-			'error',
-			{
-				destructuring: 'all',
-			},
-		],
-		'arrow-body-style': [2, 'as-needed'],
-		'no-unused-expressions': [
-			2,
-			{
-				allowTaggedTemplates: true,
-			},
-		],
-		'no-param-reassign': [
-			2,
-			{
-				props: false,
-			},
-		],
-		'max-len': [
-			'warn',
-			{
-				code: 100,
-				ignoreComments: true,
-				ignoreTrailingComments: true,
-				ignoreUrls: true,
-				ignoreStrings: true,
-				ignoreTemplateLiterals: true,
-				ignoreRegExpLiterals: true,
-			},
-		],
-		'no-console': 0,
-		'import/prefer-default-export': 0,
-		import: 0,
-		'func-names': 0,
-		'space-before-function-paren': 0,
-		'comma-dangle': 0,
-		'import/extensions': 0,
-		'no-underscore-dangle': 0,
-		'consistent-return': 0,
-		'react/display-name': 1,
-		'react/no-array-index-key': 0,
-		'react/react-in-jsx-scope': 0,
-		'react/prefer-stateless-function': 0,
-		'react/forbid-prop-types': 0,
-		'react/no-unescaped-entities': 0,
-		'jsx-a11y/accessible-emoji': 0,
-		'react/require-default-props': 0,
-		'react/jsx-props-no-spreading': 0,
-		'react/jsx-filename-extension': [
-			2,
-			{
-				extensions: ['.js', '.jsx', '.ts', '.tsx'],
-			},
-		],
-		radix: 0,
-		'no-shadow': [
-			2,
-			{
-				hoist: 'all',
-				allow: ['resolve', 'reject', 'done', 'next', 'err', 'error'],
-			},
-		],
-		quotes: [
-			2,
-			'single',
-			{
-				avoidEscape: true,
-				allowTemplateLiterals: true,
-			},
-		],
-		'jsx-a11y/href-no-hash': 'off',
-		'jsx-a11y/anchor-is-valid': [
-			'warn',
-			{
-				aspects: ['invalidHref'],
-			},
-		],
-		'react-hooks/rules-of-hooks': 'error',
-		'react-hooks/exhaustive-deps': 'warn',
-		'react/prop-types': 'warn',
-		'import/no-extraneous-dependencies': [
-			'error',
-			{
-				devDependencies: true,
-			},
-		],
-		'dot-notation': [
-			'error',
-			{
-				allowKeywords: true,
-				allowPattern: '^[a-z]+(_[a-z]+)+$',
-			},
-		],
-		indent: 0,
-		'react/jsx-indent': 0,
-		'react/jsx-indent-props': 0,
-		'react/jsx-one-expression-per-line': 0,
-		'import/order': ['warn', { 'newlines-between': 'always' }],
-	},
-	settings: {
-		'import/extensions': ['.ts', '.tsx', '.js', '.jsx'],
-		'import/resolver': {
-			node: {
-				extensions: ['.ts', '.tsx', '.js', '.jsx'],
-			},
-		},
-	},
+    extends: ['airbnb', 'prettier', 'eslint:recommended'],
+    parser: '@babel/eslint-parser',
+    parserOptions: {
+        ecmaVersion: 2020,
+        requireConfigFile: false,
+        ecmaFeatures: {
+            jsx: true,
+        },
+        babelOptions: {
+            presets: ['@babel/preset-react'],
+        },
+    },
+    env: {
+        browser: true,
+        node: true,
+        jquery: true,
+        jest: true,
+    },
+    plugins: ['html', 'prettier', 'react-hooks'],
+    rules: {
+        'prettier/prettier': [
+            'error',
+            {
+                trailingComma: 'es5',
+                singleQuote: true,
+                printWidth: 80,
+                bracketSpacing: true,
+                tabWidth: 4,
+                useTabs: false,
+                semi: true,
+                endOfLine: 'auto',
+            },
+        ],
+        'no-use-before-define': 'off',
+        'no-debugger': 0,
+        'no-alert': 0,
+        'no-await-in-loop': 0,
+        'no-return-assign': ['error', 'except-parens'],
+        'no-restricted-syntax': [
+            2,
+            'ForInStatement',
+            'LabeledStatement',
+            'WithStatement',
+        ],
+        'no-redeclare': 'off',
+        'no-unused-vars': [
+            1,
+            {
+                ignoreRestSiblings: true,
+                argsIgnorePattern: 'res|next|^err',
+            },
+        ],
+        'prefer-const': [
+            'error',
+            {
+                destructuring: 'all',
+            },
+        ],
+        'arrow-body-style': [2, 'as-needed'],
+        'no-unused-expressions': [
+            2,
+            {
+                allowTaggedTemplates: true,
+            },
+        ],
+        'no-param-reassign': [
+            2,
+            {
+                props: false,
+            },
+        ],
+        'max-len': [
+            'warn',
+            {
+                code: 100,
+                ignoreComments: true,
+                ignoreTrailingComments: true,
+                ignoreUrls: true,
+                ignoreStrings: true,
+                ignoreTemplateLiterals: true,
+                ignoreRegExpLiterals: true,
+            },
+        ],
+        'no-console': 0,
+        'import/prefer-default-export': 0,
+        import: 0,
+        'func-names': 0,
+        'space-before-function-paren': 0,
+        'comma-dangle': 0,
+        'import/extensions': 0,
+        'no-underscore-dangle': 0,
+        'consistent-return': 0,
+        'react/display-name': 1,
+        'react/no-array-index-key': 0,
+        'react/react-in-jsx-scope': 0,
+        'react/prefer-stateless-function': 0,
+        'react/forbid-prop-types': 0,
+        'react/no-unescaped-entities': 0,
+        'jsx-a11y/accessible-emoji': 0,
+        'react/require-default-props': 0,
+        'react/jsx-props-no-spreading': 0,
+        'react/jsx-filename-extension': [
+            2,
+            {
+                extensions: ['.js', '.jsx', '.ts', '.tsx'],
+            },
+        ],
+        radix: 0,
+        'no-shadow': [
+            2,
+            {
+                hoist: 'all',
+                allow: ['resolve', 'reject', 'done', 'next', 'err', 'error'],
+            },
+        ],
+        quotes: [
+            2,
+            'single',
+            {
+                avoidEscape: true,
+                allowTemplateLiterals: true,
+            },
+        ],
+        'jsx-a11y/href-no-hash': 'off',
+        'jsx-a11y/anchor-is-valid': [
+            'warn',
+            {
+                aspects: ['invalidHref'],
+            },
+        ],
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
+        'react/prop-types': 'warn',
+        'import/no-extraneous-dependencies': [
+            'error',
+            {
+                devDependencies: true,
+            },
+        ],
+        'dot-notation': [
+            'error',
+            {
+                allowKeywords: true,
+                allowPattern: '^[a-z]+(_[a-z]+)+$',
+            },
+        ],
+        indent: 0,
+        'react/jsx-indent': 0,
+        'react/jsx-indent-props': 0,
+        'react/jsx-no-bind': 0,
+        'react/jsx-one-expression-per-line': 0,
+        'import/order': ['warn', { 'newlines-between': 'always' }],
+    },
+    settings: {
+        'import/extensions': ['.ts', '.tsx', '.js', '.jsx'],
+        'import/resolver': {
+            node: {
+                extensions: ['.ts', '.tsx', '.js', '.jsx'],
+            },
+        },
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
 	"name": "eslint-config-sandricoprovo",
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "eslint-config-sandricoprovo",
-			"version": "3.0.5",
+			"version": "3.0.6",
 			"license": "MIT",
+			"dependencies": {
+				"@types/react": "^17.0.38"
+			},
 			"devDependencies": {
 				"@babel/core": "^7.16.7",
 				"@babel/eslint-parser": "^7.15.7",
@@ -626,6 +629,26 @@
 			"integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ==",
 			"dev": true
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.4",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+		},
+		"node_modules/@types/react": {
+			"version": "17.0.38",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+			"integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/scheduler": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -1166,6 +1189,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/csstype": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
 		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
@@ -3957,6 +3985,26 @@
 			"integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ==",
 			"dev": true
 		},
+		"@types/prop-types": {
+			"version": "15.7.4",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+		},
+		"@types/react": {
+			"version": "17.0.38",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+			"integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+			"requires": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"@types/scheduler": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -4320,6 +4368,11 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"csstype": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
 		"eslint-plugin-react-hooks": "^4.2.0",
 		"prettier": "^2.4.1",
 		"typescript": "^4.4.3"
+	},
+	"dependencies": {
+		"@types/react": "^17.0.38"
 	}
 }

--- a/typescript.js
+++ b/typescript.js
@@ -1,56 +1,57 @@
 module.exports = {
-	globals: {
-		React: true,
-		JSX: true,
-	},
-	// These are all of the rule sets being extended
-	extends: [
-		'plugin:@typescript-eslint/recommended',
-		'airbnb-typescript',
-		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
-		// Extend rules from .eslintrc.js
-		'./.eslintrc.js',
-	],
-	// Allows ESlint to lint typescript code
-	parser: '@typescript-eslint/parser',
-	parserOptions: {
-		project: './tsconfig.json',
-	},
-	plugins: ['@typescript-eslint'],
-	settings: {
-		'import/parsers': {
-			'@typescript-eslint/parser': ['.ts', '.tsx'],
-		},
-		'import/resolver': {
-			node: {
-				extensions: ['.ts', '.tsx', '.js', '.jsx'],
-			},
-			typescript: {
-				alwaysTryTypes: true,
-			},
-		},
-		'import/extensions': ['.ts', '.tsx', '.js', '.jsx'],
-	},
-	// Typescript specific rules
-	rules: {
-		'no-redeclare': 'off',
-		'import/no-unresolved': 'error',
-		'@typescript-eslint/no-explicit-any': 'off',
-		'@typescript-eslint/no-use-before-define': 'off',
-		'@typescript-eslint/no-floating-promises': 'off',
-		'@typescript-eslint/no-var-requires': 0,
-		'@typescript-eslint/no-misused-promises': [
-			'error',
-			{
-				checksVoidReturn: false,
-			},
-		],
-		'@typescript-eslint/no-redeclare': [
-			'warn',
-			{
-				ignoreDeclarationMerge: true,
-			},
-		],
-	},
+    globals: {
+        React: true,
+        JSX: true,
+    },
+    // These are all of the rule sets being extended
+    extends: [
+        'plugin:@typescript-eslint/recommended',
+        'airbnb-typescript',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+        // Extend rules from .eslintrc.js
+        './.eslintrc.js',
+    ],
+    // Allows ESlint to lint typescript code
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        project: './tsconfig.json',
+    },
+    plugins: ['@typescript-eslint'],
+    settings: {
+        'import/parsers': {
+            '@typescript-eslint/parser': ['.ts', '.tsx'],
+        },
+        'import/resolver': {
+            node: {
+                extensions: ['.ts', '.tsx', '.js', '.jsx'],
+            },
+            typescript: {
+                alwaysTryTypes: true,
+            },
+        },
+        'import/extensions': ['.ts', '.tsx', '.js', '.jsx'],
+    },
+    // Typescript specific rules
+    rules: {
+        'react/prop-types': 'off',
+        'no-redeclare': 'off',
+        'import/no-unresolved': 'error',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-use-before-define': 'off',
+        '@typescript-eslint/no-floating-promises': 'off',
+        '@typescript-eslint/no-var-requires': 0,
+        '@typescript-eslint/no-misused-promises': [
+            'error',
+            {
+                checksVoidReturn: false,
+            },
+        ],
+        '@typescript-eslint/no-redeclare': [
+            'warn',
+            {
+                ignoreDeclarationMerge: true,
+            },
+        ],
+    },
 };


### PR DESCRIPTION
# Highlights

*Changes*
- Updates prettier config to 80 print width & to not use tabs. 
- Turns off some react propTypes  warnings in typescript.